### PR TITLE
修复自动化测试

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,11 +110,11 @@ jobs:
           name: run tests
           command: ./tests/start.sh
 
-  test-php70:
-    <<: *common-test
-    docker:
-      - image: circleci/php:7.0-cli
-      - image: zookeeper
+  # test-php70:
+  #   <<: *common-test
+  #   docker:
+  #     - image: circleci/php:7.0-cli
+  #     - image: zookeeper
   test-php71:
     <<: *common-test
     docker:
@@ -135,7 +135,7 @@ workflows:
   version: 2
   workflow:
     jobs:
-      - test-php70
+      # - test-php70
       - test-php71
       - test-php72
       - test-php73

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,6 +110,11 @@ jobs:
           name: run tests
           command: ./tests/start.sh
 
+  test-php70:
+    <<: *common-test
+    docker:
+      - image: circleci/php:7.0-cli
+      - image: zookeeper
   test-php71:
     <<: *common-test
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,12 +9,12 @@ jobs:
       - image: circleci/php:7.1-cli
       - image: zookeeper
     environment:
-      PHPX_VERSION: "0.1.1"
-      SWOOLE_VERSION: "4.3.3"
-      PHPX_BIN_URL: "https://github.com/swoole/phpx/releases/download/v$PHPX_VERSION/phpx"
-      PHPX_SRC_URL: "https://github.com/swoole/phpx/archive/v$PHPX_VERSION.tar.gz"
+      PHPX_VERSION: "v0.1.1"
+      SWOOLE_VERSION: "master"
+      PHPX_BIN_URL: "https://github.com/swoole/phpx/releases/download/$PHPX_VERSION/phpx"
+      PHPX_SRC_URL: "https://github.com/swoole/phpx/archive/$PHPX_VERSION.tar.gz"
       PHPX_COMPILE_CMD: "cmake . && sudo make install"
-      SWOOLE_SRC_URL: "https://github.com/swoole/swoole-src/archive/v$SWOOLE_VERSION.tar.gz"
+      SWOOLE_SRC_URL: "https://github.com/swoole/swoole-src/archive/$SWOOLE_VERSION.tar.gz"
       SWOOLE_COMPILE_CMD: "phpize && ./configure && sudo make install"
     
     steps:
@@ -70,7 +70,7 @@ jobs:
               eval "wget -O ./data/phpx.tar.gz $PHPX_SRC_URL"
             fi
 
-            eval "tar zxvf ./data/phpx.tar.gz -C ./data/ && cd ./data/phpx-$PHPX_VERSION/ && $PHPX_COMPILE_CMD"
+            eval "tar zxvf ./data/phpx.tar.gz -C ./data/ && cd ./data/phpx-${PHPX_VERSION/[Vv]/}/ && $PHPX_COMPILE_CMD"
 
       - run:
           name: download swoole src, then compile
@@ -80,7 +80,7 @@ jobs:
               eval "wget -O ./data/swoole-src.tar.gz $SWOOLE_SRC_URL"
             fi
             
-            eval "tar zxvf ./data/swoole-src.tar.gz -C ./data/ && cd ./data/swoole-src-$SWOOLE_VERSION/ && $SWOOLE_COMPILE_CMD"
+            eval "tar zxvf ./data/swoole-src.tar.gz -C ./data/ && cd ./data/swoole-src-${SWOOLE_VERSION/[Vv]/}/ && $SWOOLE_COMPILE_CMD"
 
       - run:
           name: build ext-zookeeper 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
       PHPX_SRC_URL: "https://github.com/swoole/phpx/archive/$PHPX_VERSION.tar.gz"
       PHPX_COMPILE_CMD: "cmake . && sudo make install"
       SWOOLE_SRC_URL: "https://github.com/swoole/swoole-src/archive/$SWOOLE_VERSION.tar.gz"
-      SWOOLE_COMPILE_CMD: "phpize && ./configure && sudo make install"
+      SWOOLE_COMPILE_CMD: "phpize && ./configure && sudo make -j 8 install"
     
     steps:
       - run:
@@ -119,11 +119,6 @@ jobs:
     <<: *common-test
     docker:
       - image: circleci/php:7.2-cli
-      - image: zookeeper
-  test-php70:
-    <<: *common-test
-    docker:
-      - image: circleci/php:7.0-cli
       - image: zookeeper
   test-php73:
     <<: *common-test

--- a/.circleci/run_local.sh
+++ b/.circleci/run_local.sh
@@ -4,13 +4,13 @@ set -x -e
 
 CURRENT=`pwd`
 
-export  PHPX_VERSION="0.1.1"
-export  SWOOLE_VERSION="4.3.3"
+export  PHPX_VERSION="v0.1.1"
+export  SWOOLE_VERSION="master"
 
-export  PHPX_BIN_URL="https://github.com/swoole/phpx/releases/download/v$PHPX_VERSION/phpx"
-export  PHPX_SRC_URL="https://github.com/swoole/phpx/archive/v$PHPX_VERSION.tar.gz"
+export  PHPX_BIN_URL="https://github.com/swoole/phpx/releases/download/$PHPX_VERSION/phpx"
+export  PHPX_SRC_URL="https://github.com/swoole/phpx/archive/$PHPX_VERSION.tar.gz"
 
-export  SWOOLE_SRC_URL="https://github.com/swoole/swoole-src/archive/v$SWOOLE_VERSION.tar.gz"
+export  SWOOLE_SRC_URL="https://github.com/swoole/swoole-src/archive/$SWOOLE_VERSION.tar.gz"
 
 [[ -d $CURRENT/data ]] || mkdir -p ./data
 

--- a/.circleci/run_local.sh
+++ b/.circleci/run_local.sh
@@ -4,6 +4,8 @@ set -x -e
 
 CURRENT=`pwd`
 
+phpx clean
+
 export  PHPX_VERSION="v0.1.1"
 export  SWOOLE_VERSION="master"
 
@@ -20,4 +22,8 @@ export  SWOOLE_SRC_URL="https://github.com/swoole/swoole-src/archive/$SWOOLE_VER
 
 [[ -f $CURRENT/data/swoole-src.tar.gz ]] || wget -O $CURRENT/data/swoole-src.tar.gz $SWOOLE_SRC_URL
 
-circleci local execute -e LOCAL=1 -v $CURRENT/data:/tmp/data 
+T_JOB=${JOB:=test-php72}
+
+echo "JOB=$T_JOB ./.circleci/run_local.sh";
+
+circleci local execute -e LOCAL=1 -v $CURRENT/data:/tmp/data --job $T_JOB

--- a/tests/inc/bootstrap.php
+++ b/tests/inc/bootstrap.php
@@ -6,3 +6,5 @@ define('TEST_ZOOKEEPER_TIMEOUT', getenv('TEST_ZOOKEEPER_TIMEOUT') ?: 1);
 define("TEST_ZOOKEEPER_FULL_URL", TEST_ZOOKEEPER_HOST . ":" . TEST_ZOOKEEPER_PORT);
 define('TEST_ZOOKEEPER_KEY', '/test_create_instance');
 define('TEST_ZOOKEEPER_PERSISTENT_KEY', '/test_key_persistent');
+define('TEST_ZOOKEEPER_INVALID_KEY', '/test_key_persistent/');
+define('TEST_ZOOKEEPER_NOT_EXISTS_KEY', '/test_key_not_exists');

--- a/tests/swoole_zookeeper/exists.phpt
+++ b/tests/swoole_zookeeper/exists.phpt
@@ -1,0 +1,25 @@
+--TEST--
+swoole_zookeeper: test new instance
+--SKIPIF--
+<?php 
+require __DIR__ . '/../inc/skipif.inc';
+?>
+--FILE--
+<?php
+require __DIR__ . '/../inc/bootstrap.php';
+
+use swoole\zookeeper;
+
+go(function () {
+    zookeeper::setDebugLevel(1);
+    $zk = new zookeeper(TEST_ZOOKEEPER_FULL_URL, TEST_ZOOKEEPER_TIMEOUT);
+    var_dump($zk->exists(TEST_ZOOKEEPER_INVALID_KEY), $zk->errCode);
+    var_dump($zk->exists(TEST_ZOOKEEPER_NOT_EXISTS_KEY), $zk->errCode);
+});
+Swoole\Event::wait();
+?>
+--EXPECTF--
+bool(false)
+int(-8)
+bool(false)
+int(-101)

--- a/tests/swoole_zookeeper/getAcl.phpt
+++ b/tests/swoole_zookeeper/getAcl.phpt
@@ -48,7 +48,7 @@ array(2) {
     ["numChildren"]=>
     int(0)
     ["pzxid"]=>
-    int(154)
+    int(%d)
   }
   [1]=>
   array(1) {

--- a/tests/swoole_zookeeper/getChildren.phpt
+++ b/tests/swoole_zookeeper/getChildren.phpt
@@ -17,7 +17,7 @@ go(function () {
     $zk = new zookeeper(TEST_ZOOKEEPER_FULL_URL, TEST_ZOOKEEPER_TIMEOUT);
     if (!$zk->exists(KEY))
     {
-        var_dump($zk->create(KEY, 'parent'));
+        $zk->create(KEY, 'parent');
     }
     var_dump($zk->create(KEY."/a", "hello", ZOO_EPHEMERAL), $zk->errCode);
     var_dump($zk->create(KEY."/b", "world", ZOO_EPHEMERAL), $zk->errCode);

--- a/tests/swoole_zookeeper/getChildren.phpt
+++ b/tests/swoole_zookeeper/getChildren.phpt
@@ -15,20 +15,18 @@ const KEY = "/test_dir";
 go(function () {
     zookeeper::setDebugLevel(1);
     $zk = new zookeeper(TEST_ZOOKEEPER_FULL_URL, TEST_ZOOKEEPER_TIMEOUT);
-    if (!$zk->exists(KEY))
+    if (!$zk->exists(KEY) && $zk->errCode === -101) // key 不存在
     {
         $zk->create(KEY, 'parent');
     }
-    var_dump($zk->create(KEY."/a", "hello", ZOO_EPHEMERAL), $zk->errCode);
-    var_dump($zk->create(KEY."/b", "world", ZOO_EPHEMERAL), $zk->errCode);
+    var_dump($zk->create(KEY."/a", "hello", ZOO_EPHEMERAL));
+    var_dump($zk->create(KEY."/b", "world", ZOO_EPHEMERAL));
     var_dump($zk->getChildren(KEY));
 });
 ?>
 --EXPECT--
 string(11) "/test_dir/a"
-int(0)
 string(11) "/test_dir/b"
-int(0)
 array(2) {
   [0]=>
   string(1) "a"

--- a/tests/template
+++ b/tests/template
@@ -7,5 +7,6 @@ require __DIR__ . '/../inc/skipif.inc';
 <?php
 require __DIR__ . '/../inc/bootstrap.php';
 echo true;
+Swoole\Event::wait();
 --EXPECT--
 1


### PR DESCRIPTION
1. 更新 swoole 版本到 master 分支
2. 移除 php7.0 版本测试（swoole master 分支不支持）
3. 更新 run_local.sh脚本， 支持 `JOB=$T_JOB ./.circleci/run_local.sh` 方式指定执行 job
4. 增加了 `exists` 方法部分测试